### PR TITLE
#11 - Add enrolments basic model

### DIFF
--- a/app/controllers/enrolments_controller.rb
+++ b/app/controllers/enrolments_controller.rb
@@ -1,0 +1,22 @@
+class EnrolmentsController < ApplicationController
+
+  def index
+  end
+
+  def show
+  end
+
+  def new
+    @enrolment  = Enrolment.new
+  end
+
+  def create
+  end
+
+  def update 
+  end
+
+  def destroy
+  end
+
+end

--- a/app/models/enrolment.rb
+++ b/app/models/enrolment.rb
@@ -1,0 +1,10 @@
+class Enrolment < ActiveRecord::Base
+
+
+
+
+
+
+
+
+end

--- a/app/views/enrolments/show.html.erb
+++ b/app/views/enrolments/show.html.erb
@@ -1,0 +1,1 @@
+<h3> Show the new enrolment </h3>

--- a/db/migrate/20151028091210_create_enrolments.rb
+++ b/db/migrate/20151028091210_create_enrolments.rb
@@ -1,0 +1,13 @@
+class CreateEnrolments < ActiveRecord::Migration
+  def change
+    create_table :enrolments do |t|
+      t.references :person, null: false, index: true
+      t.datetime  :date
+      t.references  :subject, null: false, index: true
+      t.datetime  :activation_date
+      t.float     :fees
+      t.boolean   :deferred?
+      t.datetime  :start_date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151028085900) do
+ActiveRecord::Schema.define(version: 20151028091210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "enrolments", force: :cascade do |t|
+    t.integer  "person_id",       null: false
+    t.datetime "date"
+    t.integer  "subject_id",      null: false
+    t.datetime "activation_date"
+    t.float    "fees"
+    t.boolean  "deferred?"
+    t.datetime "start_date"
+  end
+
+  add_index "enrolments", ["person_id"], name: "index_enrolments_on_person_id", using: :btree
+  add_index "enrolments", ["subject_id"], name: "index_enrolments_on_subject_id", using: :btree
 
   create_table "offers", force: :cascade do |t|
     t.string   "offer_name"


### PR DESCRIPTION
This pull request resolves #11.

Adds a basic enrolments model that records date, person (reference), one subject (reference), start_date, activation_date, deferred.
