### PR TITLE
#64 - Rename grade to score in PackRecord table

### DIFF
--- a/db/migrate/20151110053704_rename_grade_packrecords.rb
+++ b/db/migrate/20151110053704_rename_grade_packrecords.rb
@@ -1,0 +1,6 @@
+class RenameGradePackrecords < ActiveRecord::Migration
+  def change
+    remove_column :pack_records, :grade, :string
+    add_column :pack_records, :score, :integer, default: 0, max: 200
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151109094305) do
+ActiveRecord::Schema.define(version: 20151110053704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,14 +52,14 @@ ActiveRecord::Schema.define(version: 20151109094305) do
 
   create_table "pack_records", force: :cascade do |t|
     t.datetime "record_date"
-    t.string   "grade"
     t.string   "comment"
     t.string   "status"
     t.datetime "due_date"
-    t.integer  "pack_id",     null: false
-    t.integer  "user_id",     null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "pack_id",                 null: false
+    t.integer  "user_id",                 null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.integer  "score",       default: 0
   end
 
   add_index "pack_records", ["pack_id"], name: "index_pack_records_on_pack_id", using: :btree


### PR DESCRIPTION
This pull request resolves #64.

It alters the grade column to be a score column for a pack record with a default value of 0 and max value of 200
