### PR TITLE
#77 - Show Packs for a Student for a student to request help for

### DIFF
--- a/app/models/pack_record.rb
+++ b/app/models/pack_record.rb
@@ -8,6 +8,8 @@ class PackRecord < ActiveRecord::Base
       reward = 1.00
     elsif score >= 90 && score <= 100
       reward = 2.00
+    else
+      reward = 0.00
     end
     reward
   end

--- a/app/views/myregistrations/_student_help_required.html.erb
+++ b/app/views/myregistrations/_student_help_required.html.erb
@@ -20,7 +20,7 @@
     </div>
     <div class = "col-sm-3">
       <%= f.label :pack_name, "Pack Requiring Help: " %><br />
-      <%= f.collection_select :pack_name, Pack.all, :name, :name, :prompt => "Select pack" %>
+      <%= f.collection_select :pack_name, Pack.all.find(current_user.pack_records.pluck(:pack_id)), :name, :name, :prompt => "Select pack" %>
     </div>
     <div class = "col-sm-3">
       <%= f.label :page_number, "Page Number: " %><br />


### PR DESCRIPTION
This pull request resolves #77.

When requesting for help, the packs dropdown populates all the packs the user has in their pack records to ask questions for.

Also adds a reward of $0.00 if the appropriate score is not met.
