### PR TITLE
#48 - Allow registration emails to be sent to admins

### DIFF
--- a/app/controllers/myregistrations_controller.rb
+++ b/app/controllers/myregistrations_controller.rb
@@ -21,7 +21,8 @@ class MyregistrationsController < Devise::RegistrationsController
       respond_to do |format| 
         if @user.save
           flash[:success] = "User was created successfully."
-          UserMailer.registration_confirmation_to_user(@user).deliver
+          UserMailer.registration_confirmation_to_user(@user).deliver_now
+          AdminMailer.registration_confirmation_to_admin(@user).deliver_now
           if current_user 
             format.js { redirect_turbo parent_summary_path }
           else
@@ -33,7 +34,8 @@ class MyregistrationsController < Devise::RegistrationsController
       end
     else
       @user.save
-      UserMailer.registration_confirmation_to_user(@user).deliver
+      UserMailer.registration_confirmation_to_user(@user).deliver_now
+      AdminMailer.registration_confirmation_to_admin(@user).deliver_now
       redirect_to user_session_path
     end
   end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -10,8 +10,8 @@ class AdminMailer < ApplicationMailer
   end
 
   def registration_confirmation_to_admin(user)
-  	@user = user
-      mail(from: @user.email, to: 'tjterminator.dev@gmail.com', subject: "A new Registration")
+    @user = user
+    mail(from: @user.email, to: 'tjterminator.dev@gmail.com', subject: "A new Registration")
   end
 
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -9,4 +9,10 @@ class AdminMailer < ApplicationMailer
     end
   end
 
+  def registration_confirmation_to_admin(user)
+  	@user = user
+      mail(from: @user.email, to: 'tjterminator.dev@gmail.com', subject: "A new Registration")
+  end
+
+
 end

--- a/app/views/admin_mailer/registration_confirmation_to_admin.text.erb
+++ b/app/views/admin_mailer/registration_confirmation_to_admin.text.erb
@@ -1,0 +1,6 @@
+Admins,
+<% if @user.parent_id.present? %>
+A new enrolment has been done for the student <%=@user.full_name%> by parent <%= @user.parent.full_name%>.
+<% else %>
+A parent has setup their account on OurCompany <%=@user.full_name%> .
+<% end %>

--- a/app/views/user_mailer/registration_confirmation_to_user.text.erb
+++ b/app/views/user_mailer/registration_confirmation_to_user.text.erb
@@ -1,9 +1,13 @@
-<%= @user.role == 'student' ? @user.parent.full_name : @user.full_name%>, 
-
+<%=@user.role == 'student' ? @user.parent.full_name : @user.full_name%>, 
+<% if @user.role == 'student' %>
 Thank you for registering <%= @user.full_name %> with OurCompany. We promise that you will find the tuition we provide your child will help them excel. 
 
 Cheers
 D and O
-
+<% elsif @user.role == 'parent' %> 
+Thank you for registering yourself with OurCompany. Please go to the Parent View after signing up to add your children and enrolments for each one. We promise that you will find the tuition we provide your child will help them excel. 
+Cheers
+D and O
+<% end %> 
 
 


### PR DESCRIPTION
This pull request resolves #48.

It sends a registration email also to admins when a new user has signed up. The content varies depending on whether a student signed up or a parent did.
