### PR TITLE
#72 - Cancels accounts and sends email to parent

### DIFF
--- a/app/controllers/myregistrations_controller.rb
+++ b/app/controllers/myregistrations_controller.rb
@@ -1,5 +1,5 @@
 class MyregistrationsController < Devise::RegistrationsController
-  before_action :set_user, only: [:edit, :update, :show, :destroy, :children, :suspend]
+  before_action :set_user, only: [:edit, :update, :show, :destroy, :children, :suspend, :cancel_account]
 #  before_action :admin_only, only: [:new, :create, :update, :destroy]
   
   def index
@@ -106,6 +106,13 @@ class MyregistrationsController < Devise::RegistrationsController
     @user.save
     UserMailer.suspension_email(@user).deliver_now
     redirect_to users_path
+  end
+
+  def cancel_account()
+    @user.status = 2
+    @user.save
+    UserMailer.cancellation_email(@user).deliver_now
+    redirect_to parent_summary_path
   end
   
   private 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -12,7 +12,12 @@ class UserMailer < ApplicationMailer
 
   def suspension_email(user)
     @user = user
-    mail(:to => @user.parent.email, :subject => "Suspension of MyCompant Account")
+    mail(:to => @user.parent.email, :subject => "Suspension of MyCompany Account")
+  end
+
+  def cancellation_email(user)
+    @user = user
+    mail(:to => @user.parent.email, :subject => "Cancellation of MyCompany Account")
   end
 
 end

--- a/app/views/myregistrations/_children.html.erb
+++ b/app/views/myregistrations/_children.html.erb
@@ -26,8 +26,10 @@
         <%if current_user.role == 'parent'%>
           <td> 
             <%= link_to 'Edit', edit_user_registration_path(id: child.id), remote: true, class: "btn btn-success", id: 'edit-user-registration-link' %> 
-            <%= link_to 'Delete', user_registration_path(id: child.id), method: :delete,
-                class: "btn btn-danger", id: 'delete-user-registration-link' %>
+            <% if child.status != 'CANCELLED' %>
+              <%= link_to 'Terminate Account', cancel_child_path(id: child.id),
+                class: "btn btn-danger", id: 'cancel-user-link' %>
+            <%end%>
           </td>
         <%end%>
       </tr>

--- a/app/views/user_mailer/cancellation_email.text.erb
+++ b/app/views/user_mailer/cancellation_email.text.erb
@@ -1,0 +1,8 @@
+Dear <%= @user.parent.first_name%>
+
+Your account for your child <%= @user.full_name%> has been cancelled. You must return all materials and packs.
+
+Cheers
+D and O
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     get '/users/:id/payment_related_enquiry' => "myregistrations#payment_related_enquiry", as: :payment_related_enquiry
     get '/users/:id/children' => "myregistrations#children", as: :children
     get '/users/:id/suspend' => "myregistrations#suspend", as: :suspend_child
+    get '/users/:id/cancel' => "myregistrations#cancel_account", as: :cancel_child
   end 
   
   resources :users do 


### PR DESCRIPTION
This pull request resolves #72 

It allows parents to terminate student accounts in the parent view
It sends an email to parents about the cancellation
