### PR TITLE
#74- Ensure 52 packs in ribbon

### DIFF
--- a/app/models/ribbon.rb
+++ b/app/models/ribbon.rb
@@ -2,4 +2,9 @@ class Ribbon < ActiveRecord::Base
   belongs_to :subject, inverse_of: :ribbons
   has_many :packs, dependent: :destroy
   validates :name, :address, presence: true
+  validate :validate_packs
+
+  def validate_packs
+    errors.add(:packs, "not enough packs in the ribbon") if packs.size < 52 
+  end
 end

--- a/app/models/ribbon.rb
+++ b/app/models/ribbon.rb
@@ -7,4 +7,5 @@ class Ribbon < ActiveRecord::Base
   def validate_packs
     errors.add(:packs, "not enough packs in the ribbon") if packs.size < 52 
   end
+
 end


### PR DESCRIPTION
This pull request resolves #74.

It uses a custom validation method to ensure that there are 52 packs in a ribbon.
