### PR TITLE
#94 - Add Pack Stock Management

### DIFF
--- a/app/controllers/pack_records_controller.rb
+++ b/app/controllers/pack_records_controller.rb
@@ -19,7 +19,8 @@ class PackRecordsController < ApplicationController
     @pack_record = PackRecord.new pack_record_params
     @user = User.find(@pack_record.user_id)
     @pack = Pack.find(@pack_record.pack_id)
-    update_rewards(@user)
+    update_rewards(@user, @pack_record)
+    update_stock(@pack)
     respond_to do |format|
       if @pack_record.save
         UserMailer.new_work_email(@user, @pack).deliver_now
@@ -68,10 +69,17 @@ class PackRecordsController < ApplicationController
       return not_found! unless @user
     end
 
-    def update_rewards(user)
+    def update_rewards(user, pack_record)
       @user = user
+      @pack_record = pack_record
       @pack_record.reward = @pack_record.calculate_reward(@user, @pack_record.score, @pack_record)
       @user.rewards += @pack_record.reward
       @user.save
+    end
+
+    def update_stock(pack)
+      pack.number_unassigned = pack.number_unassigned - 1
+      pack.number_assigned += 1
+      pack.save
     end
 end

--- a/app/controllers/packs_controller.rb
+++ b/app/controllers/packs_controller.rb
@@ -49,7 +49,7 @@ class PacksController < ApplicationController
   private
 
     def pack_params
-      params.require(:pack).permit(:name, :description, :action_required, :subject_id, :pack_type, :priority)
+      params.require(:pack).permit(:name, :description, :number_unassigned, :number_assigned, :action_required, :subject_id, :pack_type, :priority)
     end
 
     def set_pack

--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -1,4 +1,4 @@
 class Enclosure < ActiveRecord::Base
-  belongs_to :pack
+  #belongs_to :pack
   enum enclosure_type: [:BOOK]
 end

--- a/app/models/pack.rb
+++ b/app/models/pack.rb
@@ -1,6 +1,6 @@
 class Pack < ActiveRecord::Base
   belongs_to :subject, inverse_of: :packs
-  has_many :enclosures, dependent: :destroy
+  #has_many :enclosures, dependent: :destroy
   validates :name, :description, presence: true
   enum pack_type: [:NORMAL, :GLOBAL, :HIGH_INTENSITY]
 end

--- a/app/views/packs/_form.html.erb
+++ b/app/views/packs/_form.html.erb
@@ -28,6 +28,14 @@
 
   <div class="form-group">
     <div class="row">
+      <div class="col-sm-12">
+        <%= f.number_field :number_unassigned, placeholder: 'Enter no of unassigned packs ', class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="row">
       <div class="col-sm-4">
         <%= f.collection_select :subject_id, Subject.all, :id, :subject_name, :prompt => "Select a subject" %>
       </div>

--- a/app/views/packs/_index.html.erb
+++ b/app/views/packs/_index.html.erb
@@ -21,7 +21,8 @@
       <th> Priority </th>
       <th> Action Required </th>
       <th> Subject </th>
-     <!-- <th> In Stock </th> -->
+      <th> Assigned </th>
+      <th> Unassigned </th>
       <% if current_user.role == 'admin' %>
         <th> Administration </th>
       <%end%>
@@ -34,6 +35,8 @@
         <td> <%= pack.priority %> </td>
         <td> <%= pack.action_required %> </td>
         <td> <%= Subject.find(pack.subject_id).subject_name %> </td>
+        <td> <%= pack.number_unassigned %> </td>
+        <td> <%= pack.number_assigned %> </td>
         <% if current_user.role == 'admin' %>
           <td> 
             <%= link_to 'Edit', edit_pack_path(id: pack.id), remote: true, class: "btn btn-success", id: 'edit-pack-link' %> 

--- a/db/migrate/20151124070110_add_stockcontrol_packs.rb
+++ b/db/migrate/20151124070110_add_stockcontrol_packs.rb
@@ -1,0 +1,7 @@
+class AddStockcontrolPacks < ActiveRecord::Migration
+  def change
+    remove_column :packs, :in_stock?, :boolean
+    add_column :packs, :number_unassigned, :integer, default: 0
+    add_column :packs, :number_assigned, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151123080339) do
+ActiveRecord::Schema.define(version: 20151124070110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,10 +69,11 @@ ActiveRecord::Schema.define(version: 20151123080339) do
     t.string  "name"
     t.text    "description"
     t.text    "action_required"
-    t.integer "subject_id",                  null: false
-    t.boolean "in_stock?"
-    t.integer "pack_type",       default: 0
-    t.integer "priority",        default: 1
+    t.integer "subject_id",                    null: false
+    t.integer "pack_type",         default: 0
+    t.integer "priority",          default: 1
+    t.integer "number_unassigned", default: 0
+    t.integer "number_assigned",   default: 0
   end
 
   add_index "packs", ["subject_id"], name: "index_packs_on_subject_id", using: :btree


### PR DESCRIPTION
This pull request resolves #94.

It adds pack stock management. When a new pack record is created, the number of unassigned packs go down by one and the number of assigned packs go up.

User can modify the number of unassigned ones if more stock is printed.

Added two database fields

Temporarily commented out pack enclosure relationship for now.
