### PR TITLE
#125 - Add new logic for fees and offers

### DIFF
--- a/app/controllers/enrolments_controller.rb
+++ b/app/controllers/enrolments_controller.rb
@@ -25,7 +25,7 @@
     @enrolment.user_id = params[:enrolment][:user_id]
     @user_enrolled = User.find(params[:enrolment][:user_id])
     @user_enrolled.enrolments << @enrolment
-    @enrolment.fees = 98
+    set_enrolment_fees
     respond_to do |format|
       if @enrolment.save
         @user_enrolled.save
@@ -71,6 +71,11 @@
     def set_user
       @user = User.find params[:user_id] 
       return not_found! unless @user
+    end
+
+    def set_enrolment_fees
+      @fee = Fee.all.where(subject_id: @enrolment.subject_id, fee_type: 1).first.amount
+      @enrolment.fees = @fee
     end
 
 end

--- a/app/controllers/fees_controller.rb
+++ b/app/controllers/fees_controller.rb
@@ -1,0 +1,60 @@
+ class FeesController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_fee, only: [:edit, :update, :show, :destroy]
+ # before_action :admin_only, only: [:new, :create, :update, :destroy]
+  
+  def index
+    @fees = Fee.all
+  end
+
+  def show
+    @fee = Fee.find(params[:id])
+  end
+
+  def new
+    @fee  = Fee.new
+  end
+
+   def create
+    @fee = Fee.new fee_params
+    respond_to do |format|
+      if @fee.save
+        flash[:success] = "Fee was created successfully."
+        format.js { redirect_turbo admin_path}
+      else
+        format.js { render partial: 'shared/ajax_form_errors', locals: {model: @fee}, status: 500 }
+      end
+    end
+  end
+
+  def edit
+  end
+  
+  def update
+    respond_to do |format|
+      if @fee.update_attributes fee_params
+        flash[:success] = "Fee was updated successfully."
+        format.js {redirect_turbo admin_path}
+      else
+        format.js { render partial: 'shared/ajax_form_errors', locals: {model: @fee}, status: 500 }
+      end
+    end
+  end
+
+  def destroy
+    @fee.destroy
+    redirect_to admin_path
+  end
+
+  private
+
+    def fee_params
+      params.require(:fee).permit(:start_date, :end_date, :amount, :fee_type, :subject_id)
+    end
+
+    def set_fee
+      @fee = Fee.find params[:id] rescue nil
+      return not_found! unless @fee
+    end
+
+end

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -17,7 +17,6 @@
 
    def create
     @offer = Offer.new offer_params
-    binding.pry
     respond_to do |format|
       if @offer.save
         flash[:success] = "Offer was created successfully."

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -17,9 +17,10 @@
 
    def create
     @offer = Offer.new offer_params
+    binding.pry
     respond_to do |format|
       if @offer.save
-        flash[:success] = "Pack was created successfully."
+        flash[:success] = "Offer was created successfully."
         format.js { redirect_turbo admin_path}
       else
         format.js { render partial: 'shared/ajax_form_errors', locals: {model: @offer}, status: 500 }
@@ -49,7 +50,7 @@
   private
 
     def offer_params
-      params.require(:offer).permit(:offer_name, :offer_description, :start_date, :end_date, :includes_free_trial)
+      params.require(:offer).permit(:offer_name, :offer_description, :start_date, :end_date, :includes_free_trial, :discount_amount, :percentage_discount, :number_of_subjects)
     end
 
     def set_offer

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -1,0 +1,6 @@
+class Fee < ActiveRecord::Base
+  enum fee_type: [:ENROLMENT, :MONTHLY, :DEFERMENT, :CONTINGENCY]
+
+
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,14 +11,28 @@ class User < ActiveRecord::Base
   #enum role: [:PARENT, :STUDENT, :EMPLOYER, :ADMIN]
   enum status: [:ACTIVE, :SUSPENDED, :CANCELLED]
 
-  def calculate_fees (user)
+  def calculate_total_fees (user)
     total_fees = 0
+    subject_enrolment_fees = calculate_subject_enrolment_fees(user)
+    enrolment_fees = calculate_enrolment_fees
+    total_fees = subject_enrolment_fees + enrolment_fees
+    user.total_fees = total_fees
+    user.save
+    total_fees
+  end
+
+  def calculate_subject_enrolment_fees(user)
+    subject_enrolment_fees = 0
     if user.role == 'student' && user.enrolments.present?
       user.enrolments.each do |enrolment| 
-        total_fees+= enrolment.fees
+        subject_enrolment_fees+= enrolment.fees
       end
     end
-    total_fees
+    subject_enrolment_fees
+  end
+
+  def calculate_enrolment_fees
+    enrolment_fee = Fee.all.where(fee_type: 0).first.amount
   end
 
   def full_name

--- a/app/views/fees/_form.html.erb
+++ b/app/views/fees/_form.html.erb
@@ -1,0 +1,46 @@
+<%= form_for @fee, url: path, title: title, remote: true, html: {mulitpart: true, class: 'well', role: 'form'} do |f| %>
+  <div id="form-errors"></div>
+  <%= label_tag(:q, title) %>
+
+  <div class="form-group">
+    <div class="row">
+      <div class="col-sm-12">
+        <%= f.date_select :start_date, placeholder: 'Enter start date', class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="row">
+      <div class="col-sm-12">
+        <%= f.date_select :end_date, placeholder: 'Enter end date', class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="row">
+      <div class="col-sm-12">
+        <%= f.number_field :amount, placeholder: 'Enter amount', class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="row">
+      <div class="col-sm-6">
+        <%= f.select :fee_type, Fee.fee_types.keys.to_a %>
+      </div>
+      <div class="col-sm-6">
+        <%= f.collection_select :subject_id, Subject.all, :id, :subject_name, :prompt => "Select Subject" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group row submit">
+    <%= button_tag type: "submit", class: "btn btn-primary", name: "commit", value: "Save" do %>
+      <a>Save</a>
+    <% end %>
+    <a class="btn btn-danger hvr-trim" id='add-fee-cancel-button' data-behaviour="form-dismiss">Cancel</a>
+  </div>
+<% end %>

--- a/app/views/fees/_index.html.erb
+++ b/app/views/fees/_index.html.erb
@@ -1,0 +1,46 @@
+<% @fees = fees if @fees.nil? %> 
+<div class = 'container'>
+  <h2> Fees</h2>
+  <div class= 'pull-right'>
+        <%= link_to 'Add Fee', new_fee_path, remote: true, class: "btn btn-primary", id: 'new-fee-link' %>
+  </div>
+
+  <div class="row">
+    <div id="new-fee-form" class="col-sm-6"></div>
+  </div>
+
+  <div class="row">
+    <div id="edit-fee-form" class="col-sm-6"></div>
+  </div>
+
+  <table class = 'table table-striped'>
+    <thead>
+      <th> Id </th>
+      <th> Type </th>
+      <th> Subject </th>
+      <th> Start Date </th>
+      <th> End Date </th>
+      <th> Amount </th>
+      <% if current_user.role == 'admin' %>
+      	<th> Administration </th>
+      <%end%>
+    </thead>
+    <% @fees.each do |fee| %>
+      <tr>
+        <td> <%= fee.id %> </td>
+        <td> <%= fee.fee_type %> </td>
+        <td> <%= Subject.find(fee.subject_id).subject_name if fee.subject_id %> </td>
+        <td> <%= fee.start_date %> </td>
+        <td> <%= fee.end_date %> </td>
+        <td> <%= number_to_currency fee.amount %> </td>
+        <% if current_user.role == 'admin' %>
+          <td> 
+            <%= link_to 'Edit', edit_fee_path(id: fee.id), remote: true, class: "btn btn-success", id: 'edit-fee-link' %> 
+            <%= link_to 'Delete', fee_path(fee), method: :delete,
+                class: "btn btn-danger", id: 'delete-fee-link' %>
+          </td>
+        <%end%>
+      </tr>
+    <%end%>
+  </table>
+</div>

--- a/app/views/fees/create.js.erb
+++ b/app/views/fees/create.js.erb
@@ -1,0 +1,5 @@
+//actions to do when submit button of create fee form has been clicked
+$("#new_fee").addClass('hidden');
+$(".new-fee-form").addClass('hidden');
+$("#new-fee-link").removeAttr('disabled', 'disabled');
+

--- a/app/views/fees/edit.js.erb
+++ b/app/views/fees/edit.js.erb
@@ -1,0 +1,32 @@
+//do the following actions when editing a fee
+$("#new-subject-form").addClass('hidden');
+$("#edit-subject-form").addClass('hidden');
+$("#new-pack-form").addClass('hidden');
+$("#edit-pack-form").addClass('hidden');
+$("#new-offer-form").addClass('hidden');
+$("#new-ribbon-form").addClass('hidden');
+$("#edit-ribbon-form").addClass('hidden');
+$("#edit-fee-link").attr('disabled', 'disabled');
+$("#edit-offer-form").addClass('hidden');
+$("#new-fee-form").addClass('hidden');
+$("#edit-fee-form").removeClass('hidden');
+$("#edit-fee-form").html("<%= j render('form', fee: @fee, remote_mode: true, title: 'Edit Fee', path: fee_path(@fee) ) %>");
+$(document).trigger('init_placeholder');
+//if click outside the form, close it and make the button enabled
+var fee = "#edit_fee_" + <%=@fee.id%>;
+var container = $(fee);
+
+$(document).mouseup(function (e) {
+    if (!container.is(e.target) && container.has(e.target).length === 0) {
+      if ( !$("#new-fee-link").is(e.target) ) {
+        container.hide();
+      };
+      $("#edit-fee-link").removeAttr('disabled', 'disabled');
+    }
+});
+
+//if cancel button is clicked, make button enabled
+$("#add-fee-cancel-button").on("click", function () {
+  $("#edit-fee-link").removeAttr('disabled', 'disabled');
+  container.hide();
+});

--- a/app/views/fees/new.js.erb
+++ b/app/views/fees/new.js.erb
@@ -1,0 +1,29 @@
+//do the following actions when creating a new fee
+$("#new-subject-form").addClass('hidden');
+$("#edit-subject-form").addClass('hidden');
+$("#new-pack-form").addClass('hidden');
+$("#edit-pack-form").addClass('hidden');
+$("#new-ribbon-form").addClass('hidden');
+$("#edit-ribbon-form").addClass('hidden');
+$("#edit-offer-form").addClass('hidden');
+$("#new-offer-form").addClass('hidden');
+$("#edit-fee-form").addClass('hidden');
+$("#new-fee-form").removeClass('hidden');
+$("#new-fee-form").html('<%= j render("form", fee: @fee, title: "Add Fee", path: fees_path(@fee)) %>')
+$("#new-fee-link").attr('disabled', 'disabled');
+$(document).trigger('init_placeholder');
+$(".new-fee-form").addClass('hidden');
+
+//if click outside the form, close it and make the button enabled
+var container = $("#new-fee-form");
+$(document).mouseup(function (e) {
+    if (!container.is(e.target) && container.has(e.target).length === 0) {
+        container.hide();
+	       $("#new-fee-link").removeAttr('disabled', 'disabled');
+    }
+});
+//if cancel button is clicked, make button enabled
+$("#add-fee-cancel-button").on("click", function () {
+	$("#new-fee-link").removeAttr('disabled', 'disabled');
+	container.hide();
+});

--- a/app/views/fees/update.js.erb
+++ b/app/views/fees/update.js.erb
@@ -1,0 +1,5 @@
+//actions to do when submit button of edit fee form has been clicked
+$("#edit-fee-link").removeAttr('disabled', 'disabled');
+$("#delete-fee-link").attr('data-confirm', 'Are you sure you want to delete the fee ?')
+$("#edit-fee-form").addClass('hidden');
+$(document).trigger('fee:form_disabled');

--- a/app/views/myregistrations/_children.html.erb
+++ b/app/views/myregistrations/_children.html.erb
@@ -22,7 +22,7 @@
         <td> <%= child.date_of_birth.strftime('%D') if child.date_of_birth %> </td>
         <td> <%= number_to_currency child.rewards %> </td>
         <td> <%= number_to_currency child.overdue_fees %> </td>
-        <td> <%= number_to_currency child.calculate_fees(child) %> </td>
+        <td> <%= number_to_currency child.calculate_total_fees(child) %> </td>
         <td> <%= child.status %> </td>
         <%if current_user.role == 'parent'%>
           <td> 

--- a/app/views/offers/_form.html.erb
+++ b/app/views/offers/_form.html.erb
@@ -20,15 +20,10 @@
 
   <div class="form-group">
     <div class="row">
-      <div class="col-sm-12">
+      <div class="col-sm-6">
         <%= f.date_select :start_date, placeholder: 'Enter start date ', class: 'form-control' %>
       </div>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <div class="row">
-      <div class="col-sm-12">
+      <div class="col-sm-6">
         <%= f.date_select :end_date, placeholder: 'Enter end date ', class: 'form-control' %>
       </div>
     </div>
@@ -42,6 +37,20 @@
     </div>
   </div>
 
+ <div class="form-group">
+    <div class="row">
+      <div class="col-sm-4">
+        <%= f.number_field :discount_amount, placeholder: 'Enter discount amount', class: 'form-control' %>
+      </div>
+      <div class="col-sm-4">
+        <%= f.number_field :percentage_discount, placeholder: 'Enter percentage discount', class: 'form-control' %>
+      </div>
+      <div class="col-sm-4">
+        <%= f.number_field :number_of_subjects, placeholder: 'Enter number of subjects', class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+ 
   <div class="form-group row submit">
     <%= button_tag type: "submit", class: "btn btn-primary", name: "commit", value: "Save" do %>
       <a>Save</a>

--- a/app/views/offers/_index.html.erb
+++ b/app/views/offers/_index.html.erb
@@ -19,6 +19,9 @@
       <th> Description </th>
       <th> Start Date </th>
       <th> End Date </th>
+      <th> Disount Amount </th>
+      <th> Percentage Discount </th>
+      <th> Number of Subjects </th>
       <th> Free trial </th>
       <% if current_user.role == 'admin' %>
       	<th> Administration </th>
@@ -30,6 +33,9 @@
         <td> <%= offer.offer_description %> </td>
         <td> <%= offer.start_date %> </td>
         <td> <%= offer.end_date %> </td>
+        <td> <%= number_to_currency offer.discount_amount %> </td>
+        <td> <%= offer.percentage_discount %> </td>
+        <td> <%= offer.number_of_subjects %> </td>
         <td> <%= offer.includes_free_trial %> </td>
         <% if current_user.role == 'admin' %>
           <td> 

--- a/app/views/pages/admin.html.erb
+++ b/app/views/pages/admin.html.erb
@@ -8,6 +8,10 @@
     <%= render partial: 'offers/index', locals: {offers: Offer.all} %>
   </div>
 
+  <div class = 'fees' >
+    <%= render partial: 'fees/index', locals: {fees: Fee.all} %>
+  </div>
+
   <div class = 'packs'>
     <%= render partial: 'packs/index', locals: {packs: Pack.all} %>  
   </div>  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   resources :ribbons
   resources :subjects
   resources :offers
+  resources :fees
   resources :messages
   resources :pack_records
 

--- a/db/migrate/20151124081814_add_newofferfields_offers.rb
+++ b/db/migrate/20151124081814_add_newofferfields_offers.rb
@@ -1,0 +1,7 @@
+class AddNewofferfieldsOffers < ActiveRecord::Migration
+  def change
+    add_column :offers, :discount_amount, :float, default: 0
+    add_column :offers, :percentage_discount, :integer, default: 0
+    add_column :offers, :number_of_subjects, :integer, default: 0
+  end
+end

--- a/db/migrate/20151124084743_create_fees.rb
+++ b/db/migrate/20151124084743_create_fees.rb
@@ -1,0 +1,12 @@
+class CreateFees < ActiveRecord::Migration
+  def change
+    create_table :fees do |t|
+      t.datetime :start_date
+      t.datetime :end_date
+      t.float :amount
+      t.integer :fee_type, default: 0
+      t.references  :subject, index: true
+      t.timestamps  null: false      
+    end
+  end
+end

--- a/db/migrate/20151124091052_add_offerid_enrolments.rb
+++ b/db/migrate/20151124091052_add_offerid_enrolments.rb
@@ -1,0 +1,5 @@
+class AddOfferidEnrolments < ActiveRecord::Migration
+  def change
+    add_reference :enrolments, :offer, index: true  
+  end
+end

--- a/db/migrate/20151124093247_set_default_enrolmentsfees.rb
+++ b/db/migrate/20151124093247_set_default_enrolmentsfees.rb
@@ -1,0 +1,6 @@
+class SetDefaultEnrolmentsfees < ActiveRecord::Migration
+  def change
+    remove_column :enrolments, :fees, :float
+    add_column :enrolments, :fees, :float, default: 0
+  end
+end

--- a/db/migrate/20151124104032_add_totalfees_users.rb
+++ b/db/migrate/20151124104032_add_totalfees_users.rb
@@ -1,0 +1,5 @@
+class AddTotalfeesUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :total_fees, :float, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151124070110) do
+ActiveRecord::Schema.define(version: 20151124093247) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,17 +27,31 @@ ActiveRecord::Schema.define(version: 20151124070110) do
 
   create_table "enrolments", force: :cascade do |t|
     t.datetime "date"
-    t.integer  "subject_id",      null: false
+    t.integer  "subject_id",                    null: false
     t.datetime "activation_date"
-    t.float    "fees"
     t.boolean  "deferred?"
     t.datetime "start_date"
-    t.integer  "user_id",         null: false
-    t.integer  "grade",           null: false
+    t.integer  "user_id",                       null: false
+    t.integer  "grade",                         null: false
+    t.integer  "offer_id"
+    t.float    "fees",            default: 0.0
   end
 
+  add_index "enrolments", ["offer_id"], name: "index_enrolments_on_offer_id", using: :btree
   add_index "enrolments", ["subject_id"], name: "index_enrolments_on_subject_id", using: :btree
   add_index "enrolments", ["user_id"], name: "index_enrolments_on_user_id", using: :btree
+
+  create_table "fees", force: :cascade do |t|
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.float    "amount"
+    t.integer  "fee_type",   default: 0
+    t.integer  "subject_id"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+  end
+
+  add_index "fees", ["subject_id"], name: "index_fees_on_subject_id", using: :btree
 
   create_table "offers", force: :cascade do |t|
     t.string   "offer_name"
@@ -45,6 +59,9 @@ ActiveRecord::Schema.define(version: 20151124070110) do
     t.datetime "start_date"
     t.datetime "end_date"
     t.boolean  "includes_free_trial"
+    t.float    "discount_amount",     default: 0.0
+    t.integer  "percentage_discount", default: 0
+    t.integer  "number_of_subjects",  default: 0
   end
 
   create_table "pack_records", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151124093247) do
+ActiveRecord::Schema.define(version: 20151124104032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(version: 20151124093247) do
     t.integer  "status",                 default: 0
     t.datetime "activation_date"
     t.float    "rewards",                default: 0.0
+    t.float    "total_fees",             default: 0.0
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
This pull request resolves #125.

It fixes the fees and offers structure.

Basically a fee has a type (eg Monthly, Enrolment, Deferment, Contingency), amount, start_date, end_date, subject_id
Whilst an offer has a start_date, end_date, offer_description, offer_name, discount_amount, percentage_discount, number_of_subjects

When a new enrolment is created, the correct fees are taken from the fees table based on the fee type and subject the enrolment is created for.
