### PR TITLE
#135 - Fix subjects of admin mailer methods

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,19 +6,19 @@ class MessagesController < ApplicationController
   def create
     @message = Message.new message_params
     if @message.valid?
-      if @message.message_subject == 'Student Help'
+      if @message.message_subject == 'STUDENT NEEDS HELP'
         AdminMailer.student_enquiry(current_user, @message).deliver_now
         redirect_to student_view_path, notice: "Message sent!"
-      elsif @message.message_subject == 'Parent Help'
+      elsif @message.message_subject == 'PARENT NEEDS HELP'
         AdminMailer.parent_enquiry(current_user, @message).deliver_now
         redirect_to parent_summary_path
-      elsif @message.message_subject == 'Missing Pack'
+      elsif @message.message_subject == 'MISSING PACK/WORK'
         AdminMailer.missing_pack(current_user, @message).deliver_now
         redirect_to parent_summary_path
-      elsif @message.message_subject == 'General Parent Enquiry'
+      elsif @message.message_subject == 'PARENT GENERAL QUESTION'
         AdminMailer.general_parent_enquiry(current_user, @message).deliver_now
         redirect_to parent_summary_path
-      elsif @message.message_subject == 'Payment Related Enquiry'
+      elsif @message.message_subject == 'PAYMENT RELATED MATTERS'
         AdminMailer.payment_related_enquiry(current_user, @message).deliver_now
         redirect_to parent_summary_path
       end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -5,7 +5,7 @@ class AdminMailer < ApplicationMailer
     @user = user
     full_message = user.full_name + "(" + user.id.to_s + ") needs help with " + message.subject_name + ". In particular pack " + message.pack_name + " on page " + message.page_number + ", question number " + message.question_number + ". The following additional details have been given: " + message.content
     if @user.role == 'student'
-      mail(from: @user.email, subject: "Help Required", body: full_message)
+      mail(from: @user.email, subject: message.message_subject, body: full_message)
     end
   end
 
@@ -13,7 +13,7 @@ class AdminMailer < ApplicationMailer
     @user = user
     full_message = user.full_name + "(" + user.id.to_s + ") needs help with " + message.subject_name + ". In particular pack " + message.pack_name + " on page " + message.page_number + ", question number " + message.question_number + ". The following additional details have been given: " + message.content
     if @user.role == 'parent'
-      mail(from: @user.email, subject: "Help Requested by Parent", body: full_message)
+      mail(from: @user.email, subject: message.message_subject, body: full_message)
     end
   end
 
@@ -43,7 +43,7 @@ class AdminMailer < ApplicationMailer
   def redeem_reward(user, amount)
     @user = user
     full_message = @user.parent.full_name + ' would like to redeem their rewards for ' + user.full_name + ' of $' + amount.to_s
-    mail(from: @user.parent.email, to: 'tjterminator.dev@gmail.com', subject: 'Reward Redeemed', body: full_message)
+    mail(from: @user.parent.email, to: 'tjterminator.dev@gmail.com', subject: 'REWARD REDEMPTION', body: full_message)
   end
 
 end

--- a/app/views/myregistrations/_general_parent_enquiry.html.erb
+++ b/app/views/myregistrations/_general_parent_enquiry.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class = "row">
     <div class = "col-md-6">
-      <%= f.hidden_field :message_subject, value: 'General Parent Enquiry'%>
+      <%= f.hidden_field :message_subject, value: 'PARENT GENERAL QUESTION'%>
     </div>
   </div>
   <div class="actions"><%= f.submit "Send Request" %></div>

--- a/app/views/myregistrations/_missing_pack.html.erb
+++ b/app/views/myregistrations/_missing_pack.html.erb
@@ -15,7 +15,7 @@
 
   <div class = "row">
     <div class = "col-md-6">
-      <%= f.hidden_field :message_subject, value: 'Missing Pack'%>
+      <%= f.hidden_field :message_subject, value: 'MISSING PACK/WORK'%>
     </div>
     <div class = "col-sm-3">
       <%= f.label :pack_name, "Pack Missing: " %><br />

--- a/app/views/myregistrations/_parent_help_required.html.erb
+++ b/app/views/myregistrations/_parent_help_required.html.erb
@@ -39,7 +39,7 @@
   </div>
   <div class = "row" >
     <div class = "col-md-6">
-      <%= f.hidden_field :message_subject, value: 'Parent Help'%>
+      <%= f.hidden_field :message_subject, value: 'PARENT NEEDS HELP'%>
     </div>
   </div>
   <div class="actions"><%= f.submit "Send Request" %></div>

--- a/app/views/myregistrations/_payment_related_enquiry.html.erb
+++ b/app/views/myregistrations/_payment_related_enquiry.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class = "row">
     <div class = "col-md-6">
-      <%= f.hidden_field :message_subject, value: 'Payment Related Enquiry'%>
+      <%= f.hidden_field :message_subject, value: 'PAYMENT RELATED MATTERS'%>
     </div>
   </div>
 

--- a/app/views/myregistrations/_student_help_required.html.erb
+++ b/app/views/myregistrations/_student_help_required.html.erb
@@ -39,7 +39,7 @@
   </div>
   <div class = "row">
     <div class = "col-md-6">
-      <%= f.hidden_field :message_subject, value: 'Student Help'%>
+      <%= f.hidden_field :message_subject, value: 'STUDENT NEEDS HELP'%>
     </div>
   </div>
 


### PR DESCRIPTION
This pull request resolves #135 

It fixes the subject line of the emails sent to admins based on requirements from client of:
MISSING PACK/WORK, STUDENT NEEDS HELP, PARENT NEEDS HELP, PARENT GENERAL QUESTION, PAYMENT RELATED MATTERS
