### PR TITLE
#85 - Setup basic content for Fees and Offers page

### DIFF
--- a/app/views/fees/_index.html.erb
+++ b/app/views/fees/_index.html.erb
@@ -2,7 +2,7 @@
 <div class = 'container'>
   <h2> Fees</h2>
   <div class= 'pull-right'>
-        <%= link_to fa_icon("plus", text: 'Add Fee'), new_fee_path, remote: true, class: "btn btn-primary", id: 'new-fee-link' %>
+        <%= link_to fa_icon("plus", text: 'Add Fee'), new_fee_path, remote: true, class: "btn btn-primary", id: 'new-fee-link' if current_user && current_user.role == 'admin' %>
   </div>
 
   <div class="row">
@@ -21,7 +21,7 @@
       <th> Start Date </th>
       <th> End Date </th>
       <th> Amount </th>
-      <% if current_user.role == 'admin' %>
+      <% if current_user && current_user.role == 'admin' %>
       	<th> Administration </th>
       <%end%>
     </thead>
@@ -33,7 +33,7 @@
         <td> <%= fee.start_date %> </td>
         <td> <%= fee.end_date %> </td>
         <td> <%= number_to_currency fee.amount %> </td>
-        <% if current_user.role == 'admin' %>
+        <% if current_user && current_user.role == 'admin' %>
           <td> 
             <%= link_to 'Edit', edit_fee_path(id: fee.id), remote: true, class: "btn btn-success", id: 'edit-fee-link' %> 
             <%= link_to 'Delete', fee_path(fee), method: :delete,

--- a/app/views/offers/_index.html.erb
+++ b/app/views/offers/_index.html.erb
@@ -2,7 +2,7 @@
 <div class = 'container'>
   <h2> Offers</h2>
   <div class= 'pull-right'>
-        <%= link_to fa_icon("plus", text: 'Add Offer'), new_offer_path, remote: true, class: "btn btn-primary", id: 'new-offer-link' %>
+        <%= link_to fa_icon("plus", text: 'Add Offer'), new_offer_path, remote: true, class: "btn btn-primary", id: 'new-offer-link' if current_user && current_user.role == 'admin' %>
   </div>
 
   <div class="row">
@@ -19,11 +19,11 @@
       <th> Description </th>
       <th> Start Date </th>
       <th> End Date </th>
-      <th> Disount Amount </th>
+      <th> Discount Amount </th>
       <th> Percentage Discount </th>
       <th> Number of Subjects </th>
       <th> Free trial </th>
-      <% if current_user.role == 'admin' %>
+      <% if current_user && current_user.role == 'admin' %>
       	<th> Administration </th>
       <%end%>
     </thead>
@@ -37,7 +37,7 @@
         <td> <%= offer.percentage_discount %> </td>
         <td> <%= offer.number_of_subjects %> </td>
         <td> <%= offer.includes_free_trial %> </td>
-        <% if current_user.role == 'admin' %>
+        <% if current_user && current_user.role == 'admin' %>
           <td> 
             <%= link_to 'Edit', edit_offer_path(id: offer.id), remote: true, class: "btn btn-success", id: 'edit-offer-link' %> 
             <%= link_to 'Delete', offer_path(offer), method: :delete,

--- a/app/views/pages/fees_offers.html.erb
+++ b/app/views/pages/fees_offers.html.erb
@@ -1,27 +1,22 @@
-<div class = 'fees'>
+<div class = 'container'>
   <h2> Fees and Offers </h2>
-  <table class='table table-striped'> 
-    <thead> 
-      <th> Column 1 </th>
-      <th> Column 2</th>
-      <th> Column 3 </th>
-    </thead>
-    <tr> 
-      <td> Row 1a </td>
-      <td> Row 1b </td>
-      <td> Row 1c </td>
-    </tr>
-    <tr> 
-      <td> Row 2a </td>
-      <td> Row 2b </td>
-      <td> Row 2c </td>
-    </tr>
-    <tr> 
-      <td> Row 3a </td>
-      <td> Row 3b </td>
-      <td> Row 3c </td>
-    </tr>
-  </table>
 
+  <ul class = 'fees-blurb'>
+    <li> Tuition is per calendar month paid in advance </li>
+    <li> All other fees and charges are waived for this offer </li>
+    <li> If enrolment occurs on the 18th on a month or after, prorated tuitiion for that month plus the tuition for the next month will be charged at enrolment. Note, there will be no double payment </li>
+    <li> If enrolment happens on the 17th of the month or before, prorated tuition for that month alone will be charged at enrolment </li>
+    <li> Before enrolment is complete, arrangement for recurring automatic payment of tuition on the first of each month should be set up </li>
+    <li> All fees are period specific, and cannot be applied to another period. For example, fees paid for July 2016 would be effective on the 1st of that month and would expire on the 30th/31st of the month </li>
+    <li> You will be presented a detailed account of the payment required at the time of the enrolment </li>
+  </ul>
+  
+  <div class = 'all-fees'>
+    <%= render partial: "fees/index", locals: {fees: Fee.all} %>
+  </div>
+  
+  <div class = 'all-offers'>
+    <%= render partial: "offers/index", locals: {offers: Offer.all} %>
+  </div>
 
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,3 +4,8 @@ Pack.create(name: '5++', description: 'A pack for advanced fifth graders', actio
 Pack.create(name: '5--', description: 'A pack for less competent fifth graders', action_required: 'Nothing', subject_id: 1)
 User.create(first_name: 'Employer', surname: 'User', role: 'employer', postal_address: 'some address', email: 'employer@gmail.com', password: 'tania551')
 User.create(first_name: 'Admin', surname: 'User', role: 'admin', postal_address: 'some address', email: 'admin@gmail.com', password: 'tania551')
+Fee.create(start_date: Date.today , end_date: Date.today + 1.year , amount: 100, fee_type: 1)
+Fee.create(start_date: Date.today , end_date: Date.today + 1.year , amount: 160, fee_type: 0, subject_id: 2)
+Fee.create(start_date: Date.today , end_date: Date.today + 1.year , amount: 160, fee_type: 0, subject_id: 1)
+Offer.create(offer_name: 'Premier Group X English', offer_description: 'Starting English Offer', start_date: Date.today , end_date: Date.today + 1.year , discount_amount: 62)
+Offer.create(offer_name: 'Premier Group X Mathematics', offer_description: 'Starting Maths Offer', start_date: Date.today , end_date: Date.today + 1.year , discount_amount: 62)


### PR DESCRIPTION
This pull request resolves #85.

It adds basic content to the fees and offers page. Needs more work.

It also adds seeds for offers and fees data
