### PR TITLE
#127 - Add button to send email to overdue pack records

### DIFF
--- a/app/controllers/pack_records_controller.rb
+++ b/app/controllers/pack_records_controller.rb
@@ -53,6 +53,15 @@ class PackRecordsController < ApplicationController
     redirect_to employer_view_path
   end
 
+  def work_missing_email
+    @overdue_packs = PackRecord.overdue
+    @overdue_packs.each do |overdue_pack|
+      UserMailer.work_missing(User.find(overdue_pack.user_id), overdue_pack).deliver_now
+    end
+    redirect_to employer_view_path
+  end 
+ 
+
   private
 
     def pack_record_params

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -32,4 +32,10 @@ class UserMailer < ApplicationMailer
     mail(:to => @user.parent.email, :subject => "Rewards expiring in 1 month")
   end
 
+  def work_missing(user, pack_record)
+    @user = user
+    @pack_record = pack_record
+    mail(:to => @user.parent.email, :subject => "Work missing for OurCompany")
+  end
+
 end

--- a/app/models/pack_record.rb
+++ b/app/models/pack_record.rb
@@ -1,6 +1,7 @@
 class PackRecord < ActiveRecord::Base
   belongs_to :user
   enum status: [:DISPATCHED, :RECEIVED, :COMPLETED]
+  scope :overdue, -> { where("due_date < ?", Date.today ) }
 
   def calculate_reward(user, score, pack_record)
     if score >= 70 && score <= 79

--- a/app/views/pages/employer_view.html.erb
+++ b/app/views/pages/employer_view.html.erb
@@ -2,4 +2,5 @@
   <div class = "row">
     <%= render partial: "pack_records/index", locals: {pack_records: PackRecord.all} %>
   </div>
+  <%= link_to fa_icon("plus", text: 'Send Work Missing Email'), work_missing_path(user_id: current_user), class: "btn btn-primary", id: 'work-missing-link' if current_user && current_user.role == 'employee' %>
 </div>

--- a/app/views/user_mailer/work_missing.text.erb
+++ b/app/views/user_mailer/work_missing.text.erb
@@ -1,0 +1,8 @@
+Dear <%= @user.parent.first_name%>
+
+The pack <%= Pack.find(@pack_record.pack_id).name %> for <%= User.find(@pack_record.user_id).full_name %> has not been received by us. The pack is past its due date(<%= @pack_record.due_date.strftime('%m\%d\%Y') %>). Please send it as soon as possible.
+
+Please remember if three consecutive pieces of work are not received, your account will be suspended until the work is returned.
+
+Cheers
+D and O

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   resources :fees
   resources :messages
   resources :pack_records
+  get '/work_missing_email' => "pack_records#work_missing_email", as: :work_missing
 
   controller :pages do
     get :home


### PR DESCRIPTION
This pull request resolves #127. 

It adds a scope of overdue to pack records where due date is before today's date!

Adds a button for staff to send email on Monday's to user's to submit overdue packs
