### PR TITLE
#148 - Add named scopes to user roles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,11 @@ class User < ActiveRecord::Base
   has_many :enrolments, dependent: :destroy
   has_many :subjects, through: :enrolments, source: :subject
   enum status: [:ACTIVE, :SUSPENDED, :CANCELLED]
-
+  scope :students, -> { where(role: 'student') }
+  scope :all_parents, -> { where(role: 'parent') }
+  scope :admins, -> { where(role: 'admin') }
+  scope :employees, -> { where(role: 'employee') }
+  
   def calculate_total_fees (user)
     total_fees = 0
     subject_enrolment_fees = calculate_subject_enrolment_fees(user)


### PR DESCRIPTION
This pull request resolves #148 

It adds named scopes of admins, employees, students, all_parents for different user roles
