### PR TITLE
#116 - Auto generate posting number for pack records

### DIFF
--- a/app/controllers/pack_records_controller.rb
+++ b/app/controllers/pack_records_controller.rb
@@ -19,6 +19,7 @@ class PackRecordsController < ApplicationController
     @pack_record = PackRecord.new pack_record_params
     @user = User.find(@pack_record.user_id)
     @pack = Pack.find(@pack_record.pack_id)
+    @pack_record.posting_number = @user.pack_records.last.posting_number + 1
     update_rewards(@user, @pack_record)
     update_stock(@pack)
     respond_to do |format|
@@ -37,7 +38,7 @@ class PackRecordsController < ApplicationController
   
   def update
     @user = User.find(@pack_record.user_id)
-    update_rewards(@user)
+    update_rewards(@user, @pack_record)
     respond_to do |format|
       if @pack_record.update_attributes pack_record_params
         flash[:success] = "Pack Record was updated successfully."

--- a/app/views/pack_records/_form.html.erb
+++ b/app/views/pack_records/_form.html.erb
@@ -21,9 +21,6 @@
       <div class="col-sm-4">
         <%= f.select :status, PackRecord.statuses.keys.to_a %>
       </div>
-      <div class="col-sm-4">
-        <%= f.number_field :posting_number, placeholder: 'Enter posting number' %>
-      </div>
     </div>
   </div>
 

--- a/app/views/pages/student_view.html.erb
+++ b/app/views/pages/student_view.html.erb
@@ -1,6 +1,6 @@
 <div id = 'student-view-header'>
   <h2> Welcome <%=current_user.full_name %></h2>
-  <h4> <i> Your current rewards is <%= number_to_currency current_user.calculate_total_rewards(current_user) %> .</i> </h4>
+  <h4> <i> Your current rewards is <%= number_to_currency current_user.rewards %> .</i> </h4>
 </div>
 <!--<div class = "col-sm-3 col-md-2 sidebar">
   <ul class = "nav nav-sidebar">


### PR DESCRIPTION
This pull request resolves #116.

It auto generates the posting number for pack records by getting the value of the last pack records post number and auto incrementing it. It also fixes two bugs with reference to update_rewards missing one parameter and also fixes broken reference to rewards in user. It removes the field to manually enter posting number in the pack records form too.
