### PR TITLE
#192 - Ensure current offers displayed on enrolments page

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,3 +1,4 @@
 class Offer < ActiveRecord::Base 
   validates   :offer_name, :start_date, :end_date, presence: true
+  scope :active, -> { where("start_date <= :now AND end_date >= :now ", { now: DateTime.now } ) }
 end

--- a/app/views/enrolments/_form.html.erb
+++ b/app/views/enrolments/_form.html.erb
@@ -17,7 +17,7 @@
         <%= f.number_field :grade, min: 1, max: 7 %>
       </div>
       <div class = "col-md-5">
-        <%= f.collection_select :offer_id, Offer.all, :id, :offer_name, :prompt => "Select Offer" %>
+        <%= f.collection_select :offer_id, Offer.active, :id, :offer_name, :prompt => "Select Offer" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This pull request resolves #192 and ensures active offers are only displayed on enrolments page
