### PR TITLE
#196 - Remind admins to nullify rewards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
+gem 'whenever', :require => false
 
 #Maintain seed data
 gem 'seed-fu', '~> 2.3'   

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chronic (0.10.2)
     coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -245,6 +246,8 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     wicked_pdf (1.0.3)
     wkhtmltopdf-binary (0.9.9.3)
     wkhtmltopdf-heroku (2.12.3.0)
@@ -296,6 +299,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   vcr
   web-console (~> 2.0)
+  whenever
   wicked_pdf
   wkhtmltopdf-binary
   wkhtmltopdf-heroku

--- a/app/controllers/myregistrations_controller.rb
+++ b/app/controllers/myregistrations_controller.rb
@@ -150,6 +150,10 @@ class MyregistrationsController < Devise::RegistrationsController
     end
   end
 
+  def nullify_rewards
+    ValidatorMod.nullify_rewards
+  end
+
   def enter_placement_pack
     @students = User.students
     respond_to do |format|

--- a/app/controllers/myregistrations_controller.rb
+++ b/app/controllers/myregistrations_controller.rb
@@ -152,6 +152,7 @@ class MyregistrationsController < Devise::RegistrationsController
 
   def nullify_rewards
     ValidatorMod.nullify_rewards
+    redirect_to employee_view_path
   end
 
   def enter_placement_pack

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -52,5 +52,9 @@ class AdminMailer < ApplicationMailer
     mail(:to => @user.parent.email, :subject => "NEW ENROLMENT")
   end
 
+  def reminder_nullify_rewards
+    mail(:to => 'tjterminator.dev@gmail.com', from: 'tanzjacob@gmail.com', subject: 'HI')
+  end
+
 
 end

--- a/app/views/admin_mailer/reminder_nullify_rewards.text.erb
+++ b/app/views/admin_mailer/reminder_nullify_rewards.text.erb
@@ -1,0 +1,3 @@
+Dear D and O,
+
+Just a reminder to nullify all the user rewards as its been two weeks.

--- a/app/views/pages/employee_view.html.erb
+++ b/app/views/pages/employee_view.html.erb
@@ -5,7 +5,8 @@
 
   <%= link_to fa_icon("plus", text: 'Send Work Missing Email'), work_missing_path(user_id: current_user), class: "btn btn-primary hvr-sweep-to-right", id: 'work-missing-link' if current_user && current_user.role == 'employee' %>
   <%= link_to fa_icon("plus", text: 'Enter Placement Pack'), enter_placement_pack_path(id: current_user), class: "btn btn-primary hvr-sweep-to-right", id: 'placement-pack-link' if current_user && current_user.role == 'employee' %>
-    
+  <%= link_to fa_icon("plus", text: 'Nullify Rewards'), nullify_rewards_path(id: current_user), class: "btn btn-primary hvr-sweep-to-right", id: 'nullify-rewards-link' if current_user && current_user.role == 'employee' %>
+
     <h1> Send Message </h1>
     <% message = Message.new%>
     <%= form_for message do |f| %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -231,7 +231,7 @@ Devise.setup do |config|
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete
-
+  config.secret_key = 'bf3bd6ae75e5671961d97395b9a25e32bd316cd964e32ec92ce8ad7f96c1edfcc537da2f57a16a6bb28543ecf12642e7a6b51aa65ab7c592a86d803ef843c016'
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     get '/users/:id/enter_placement_pack' => "myregistrations#enter_placement_pack", as: :enter_placement_pack
     get '/users/:id/missing_payment' => "myregistrations#missing_payment", as: :missing_payment
     get '/users/:id/recommend_us' => "myregistrations#recommend_us", as: :recommend_us
+    get '/users/:id/nullify_rewards' => "myregistrations#nullify_rewards", as: :nullify_rewards
   end
 
   match "/404", :to => "errors#not_found", :via => :all

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,5 @@
+set :output, "log/cron_log.log"
+
+every 14.days do
+  runner "AdminMailer.reminder_nullify_rewards.deliver_now"
+end

--- a/lib/validator_mod.rb
+++ b/lib/validator_mod.rb
@@ -11,4 +11,11 @@ module ValidatorMod
     end 
   end
 
+  def nullify_rewards
+    students = User.students 
+    students.each do |student|
+      student.update_attribute(:rewards, 0)
+    end
+  end  
+
 end


### PR DESCRIPTION
This pull request resolves #196. It reminds admins to nullify rewards every 2 weeks via email. It also adds the utility to nullify rewards from employee panel
